### PR TITLE
Update regex to match on equal symbol

### DIFF
--- a/lib/helper/QubitHelper.php
+++ b/lib/helper/QubitHelper.php
@@ -552,7 +552,7 @@ if (!defined('AR_AUTO_LINK_RE'))
       [-\w@]+                                       # subdomain or domain
       (?:\.[-\w@]+)*                                # remaining subdomains or domain
       (?::\d+)?                                     # port
-      (?:/(?:(?:[\~\w\+%-]|(?:[,.;:][^\s$]))+)?)*   # path
+      (?:/(?:(?:[\~\w\+=%-]|(?:[,.;:][^\s$]))+)?)*  # path
       (?:\?[\w\+\/%&=.;-]+)?                        # query string
       (?:\#[\w\-/\?!=]*)?                           # trailing anchor
     )


### PR DESCRIPTION
It now matches on `http://catalogue.library.ryerson.ca/record=b2613135~S0` where as before it only matched on the part of the URL before the equals symbol: `http://catalogue.library.ryerson.ca/record`
